### PR TITLE
Fixed installation issue and updated the extension to work on http and https

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
 	"name": "Fix Sharepoint Scrolling",
 	"version": "0.1",
-	"homepage_url": "https://github.com/lmartinking/fix-sharepoint",
+	"homepage_url": "https://github.com/lmartinking/fix-sharepoint-scrolling",
 	"description": "Fixes Microsoft Sharepoint Stupidity With Regards To Scrolling on non-IE browsers",
 
 	"content_scripts": [ {
 		"matches": [
-			"http://*/*.aspx*"
+			"*://*/*.aspx*"
 		],
 		"js": [
 			"lib/jquery.js",
@@ -18,5 +18,6 @@
 		"128": "icon.png"
 	},
 
-	"permissions": [ "http://*" ]
+	"permissions": [ "*://*/" ],
+	"manifest_version": 2
 }


### PR DESCRIPTION
This fixes an installation issue:

There were warnings when trying to install this extension:
Permission 'http://*' is unknown or URL pattern is malformed.

The manifest was also updated to version 2, so that chrome would stop complaining.

If you could update the extension in the chrome web store as well, I know about 25 people who would appreciate it.
